### PR TITLE
Add rate limit for confirm password

### DIFF
--- a/resources/views/livewire/auth/confirm-password.blade.php
+++ b/resources/views/livewire/auth/confirm-password.blade.php
@@ -1,6 +1,9 @@
 <?php
 
+use Illuminate\Auth\Events\Lockout;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Layout;
 use Livewire\Volt\Component;
@@ -17,18 +20,52 @@ new #[Layout('components.layouts.auth')] class extends Component {
             'password' => ['required', 'string'],
         ]);
 
+        $this->ensureIsNotRateLimited();
+
         if (! Auth::guard('web')->validate([
             'email' => Auth::user()->email,
             'password' => $this->password,
         ])) {
+            RateLimiter::hit($this->throttleKey());
             throw ValidationException::withMessages([
                 'password' => __('auth.password'),
             ]);
         }
 
+        RateLimiter::clear($this->throttleKey());
+
         session(['auth.password_confirmed_at' => time()]);
 
         $this->redirectIntended(default: route('dashboard', absolute: false), navigate: true);
+    }
+
+    /**
+     * Ensure the confirmation request is not rate limited.
+     */
+    protected function ensureIsNotRateLimited(): void
+    {
+        if (! RateLimiter::tooManyAttempts($this->throttleKey(), 5)) {
+            return;
+        }
+
+        event(new Lockout(request()));
+
+        $seconds = RateLimiter::availableIn($this->throttleKey());
+
+        throw ValidationException::withMessages([
+            'password' => __('auth.throttle', [
+                'seconds' => $seconds,
+                'minutes' => ceil($seconds / 60),
+            ]),
+        ]);
+    }
+
+    /**
+     * Get the confirmation rate limiting throttle key.
+     */
+    protected function throttleKey(): string
+    {
+        return Str::transliterate(Str::lower(Auth::user()->email).'|'.request()->ip());
     }
 }; ?>
 

--- a/tests/Feature/Auth/PasswordConfirmationTest.php
+++ b/tests/Feature/Auth/PasswordConfirmationTest.php
@@ -4,6 +4,8 @@ namespace Tests\Feature\Auth;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Str;
 use Livewire\Volt\Volt;
 use Tests\TestCase;
 
@@ -46,5 +48,27 @@ class PasswordConfirmationTest extends TestCase
             ->call('confirmPassword');
 
         $response->assertHasErrors(['password']);
+    }
+
+    public function test_password_confirmation_is_rate_limited(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+
+        for ($i = 0; $i < 5; $i++) {
+            Volt::test('auth.confirm-password')
+                ->set('password', 'wrong-password')
+                ->call('confirmPassword');
+        }
+
+        $response = Volt::test('auth.confirm-password')
+            ->set('password', 'wrong-password')
+            ->call('confirmPassword');
+
+        $key = Str::transliterate(Str::lower($user->email).'|'.request()->ip());
+
+        $response->assertHasErrors(['password']);
+        $this->assertTrue(RateLimiter::tooManyAttempts($key, 5));
     }
 }


### PR DESCRIPTION
## Summary
- enforce rate limiting in password confirmation handler
- test password confirmation rate limiting

## Testing
- `composer install --no-interaction`
- `php artisan key:generate`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_b_6867bf2deea083309273deb31e72b84b