### PR TITLE
Implement password page timeboxing

### DIFF
--- a/resources/views/livewire/auth/forgot-password.blade.php
+++ b/resources/views/livewire/auth/forgot-password.blade.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Timebox;
 use Livewire\Attributes\Layout;
 use Livewire\Volt\Component;
 
@@ -16,7 +17,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
             'email' => ['required', 'string', 'email'],
         ]);
 
-        Password::sendResetLink($this->only('email'));
+        app(Timebox::class)->call(fn () => Password::sendResetLink($this->only('email')), 200000);
 
         session()->flash('status', __('A reset link will be sent if the account exists.'));
     }

--- a/resources/views/livewire/auth/reset-password.blade.php
+++ b/resources/views/livewire/auth/reset-password.blade.php
@@ -3,6 +3,7 @@
 use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Timebox;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules;
@@ -41,17 +42,19 @@ new #[Layout('components.layouts.auth')] class extends Component {
         // Here we will attempt to reset the user's password. If it is successful we
         // will update the password on an actual user model and persist it to the
         // database. Otherwise we will parse the error and return the response.
-        $status = Password::reset(
-            $this->only('email', 'password', 'password_confirmation', 'token'),
-            function ($user) {
-                $user->forceFill([
-                    'password' => Hash::make($this->password),
-                    'remember_token' => Str::random(60),
-                ])->save();
+        $status = app(Timebox::class)->call(function () {
+            return Password::reset(
+                $this->only('email', 'password', 'password_confirmation', 'token'),
+                function ($user) {
+                    $user->forceFill([
+                        'password' => Hash::make($this->password),
+                        'remember_token' => Str::random(60),
+                    ])->save();
 
-                event(new PasswordReset($user));
-            }
-        );
+                    event(new PasswordReset($user));
+                }
+            );
+        }, 200000);
 
         // If the password was successfully reset, we will redirect the user back to
         // the application's home authenticated view. If there is an error we can

--- a/tests/Feature/Auth/PasswordTimeboxTest.php
+++ b/tests/Feature/Auth/PasswordTimeboxTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use Illuminate\Support\Timebox;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Volt\Volt;
+use Tests\TestCase;
+
+class PasswordTimeboxTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_forgot_password_uses_timebox(): void
+    {
+        $user = User::factory()->create();
+
+        $timebox = new class extends Timebox {
+            public int $calls = 0;
+
+            public function call(callable $callback, int $microseconds)
+            {
+                $this->calls++;
+
+                return $callback($this);
+            }
+        };
+
+        $this->app->instance(Timebox::class, $timebox);
+
+        Volt::test('auth.forgot-password')
+            ->set('email', $user->email)
+            ->call('sendPasswordResetLink');
+
+        $this->assertSame(1, $timebox->calls);
+    }
+
+    public function test_reset_password_uses_timebox(): void
+    {
+        $user = User::factory()->create();
+
+        $timebox = new class extends Timebox {
+            public int $calls = 0;
+
+            public function call(callable $callback, int $microseconds)
+            {
+                $this->calls++;
+
+                return $callback($this);
+            }
+        };
+
+        $this->app->instance(Timebox::class, $timebox);
+
+        Volt::test('auth.reset-password', ['token' => 'invalid'])
+            ->set('email', $user->email)
+            ->set('password', 'password')
+            ->set('password_confirmation', 'password')
+            ->call('resetPassword');
+
+        $this->assertSame(1, $timebox->calls);
+    }
+}
+


### PR DESCRIPTION
## Summary
- timebox forgot password handling
- timebox password reset logic
- test that the timebox is invoked for password operations

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_b_6867bee3c9b883309459ee17a38078b1