### PR TITLE
Add rate limiting to password reset views

### DIFF
--- a/resources/views/livewire/auth/forgot-password.blade.php
+++ b/resources/views/livewire/auth/forgot-password.blade.php
@@ -1,6 +1,10 @@
 <?php
 
+use Illuminate\Auth\Events\Lockout;
 use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Layout;
 use Livewire\Volt\Component;
 
@@ -16,9 +20,36 @@ new #[Layout('components.layouts.auth')] class extends Component {
             'email' => ['required', 'string', 'email'],
         ]);
 
+        $this->ensureIsNotRateLimited();
+
         Password::sendResetLink($this->only('email'));
 
+        RateLimiter::hit($this->throttleKey());
+
         session()->flash('status', __('A reset link will be sent if the account exists.'));
+    }
+
+    protected function ensureIsNotRateLimited(): void
+    {
+        if (! RateLimiter::tooManyAttempts($this->throttleKey(), 5)) {
+            return;
+        }
+
+        event(new Lockout(request()));
+
+        $seconds = RateLimiter::availableIn($this->throttleKey());
+
+        throw ValidationException::withMessages([
+            'email' => __('auth.throttle', [
+                'seconds' => $seconds,
+                'minutes' => ceil($seconds / 60),
+            ]),
+        ]);
+    }
+
+    protected function throttleKey(): string
+    {
+        return Str::transliterate(Str::lower($this->email).'|'.request()->ip());
     }
 }; ?>
 

--- a/resources/views/livewire/auth/reset-password.blade.php
+++ b/resources/views/livewire/auth/reset-password.blade.php
@@ -1,11 +1,14 @@
 <?php
 
+use Illuminate\Auth\Events\Lockout;
 use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules;
+use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Locked;
 use Livewire\Volt\Component;
@@ -38,6 +41,8 @@ new #[Layout('components.layouts.auth')] class extends Component {
             'password' => ['required', 'string', 'confirmed', Rules\Password::defaults()],
         ]);
 
+        $this->ensureIsNotRateLimited();
+
         // Here we will attempt to reset the user's password. If it is successful we
         // will update the password on an actual user model and persist it to the
         // database. Otherwise we will parse the error and return the response.
@@ -53,6 +58,8 @@ new #[Layout('components.layouts.auth')] class extends Component {
             }
         );
 
+        RateLimiter::hit($this->throttleKey());
+
         // If the password was successfully reset, we will redirect the user back to
         // the application's home authenticated view. If there is an error we can
         // redirect them back to where they came from with their error message.
@@ -65,6 +72,29 @@ new #[Layout('components.layouts.auth')] class extends Component {
         Session::flash('status', __($status));
 
         $this->redirectRoute('login', navigate: true);
+    }
+
+    protected function ensureIsNotRateLimited(): void
+    {
+        if (! RateLimiter::tooManyAttempts($this->throttleKey(), 5)) {
+            return;
+        }
+
+        event(new Lockout(request()));
+
+        $seconds = RateLimiter::availableIn($this->throttleKey());
+
+        throw ValidationException::withMessages([
+            'email' => __('auth.throttle', [
+                'seconds' => $seconds,
+                'minutes' => ceil($seconds / 60),
+            ]),
+        ]);
+    }
+
+    protected function throttleKey(): string
+    {
+        return Str::transliterate(Str::lower($this->email).'|'.request()->ip());
     }
 }; ?>
 

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -4,8 +4,10 @@ namespace Tests\Feature\Auth;
 
 use App\Models\User;
 use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Str;
 use Livewire\Volt\Volt;
 use Tests\TestCase;
 
@@ -72,6 +74,61 @@ class PasswordResetTest extends TestCase
             $response
                 ->assertHasNoErrors()
                 ->assertRedirect(route('login', absolute: false));
+
+            return true;
+        });
+    }
+
+    public function test_forgot_password_requests_are_rate_limited(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+
+        $key = Str::transliterate(Str::lower($user->email).'|127.0.0.1');
+        RateLimiter::clear($key);
+
+        for ($i = 0; $i < 5; $i++) {
+            Volt::test('auth.forgot-password')
+                ->set('email', $user->email)
+                ->call('sendPasswordResetLink')
+                ->assertHasNoErrors();
+        }
+
+        Volt::test('auth.forgot-password')
+            ->set('email', $user->email)
+            ->call('sendPasswordResetLink')
+            ->assertHasErrors('email');
+    }
+
+    public function test_reset_password_requests_are_rate_limited(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+
+        Volt::test('auth.forgot-password')
+            ->set('email', $user->email)
+            ->call('sendPasswordResetLink');
+
+        Notification::assertSentTo($user, ResetPassword::class, function ($notification) use ($user) {
+            $key = Str::transliterate(Str::lower($user->email).'|127.0.0.1');
+            RateLimiter::clear($key);
+
+            for ($i = 0; $i < 5; $i++) {
+                Volt::test('auth.reset-password', ['token' => $notification->token])
+                    ->set('email', $user->email)
+                    ->set('password', 'password')
+                    ->set('password_confirmation', 'password')
+                    ->call('resetPassword');
+            }
+
+            Volt::test('auth.reset-password', ['token' => $notification->token])
+                ->set('email', $user->email)
+                ->set('password', 'password')
+                ->set('password_confirmation', 'password')
+                ->call('resetPassword')
+                ->assertHasErrors('email');
 
             return true;
         });


### PR DESCRIPTION
## Summary
- implement RateLimiter checks in the forgot-password and reset-password Volt components
- extend password reset tests to cover rate limiting behaviour

## Testing
- `composer test` *(fails: composer not found)*
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_b_6867beb110088330b4a3c3c8d388eaf9